### PR TITLE
fixes compond string calculation

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,2 @@
+This product includes software developed by
+Kyaw Tun <kyawtun@yathit.com> for https://github.com/yathit/ydn-db licenced under the Apache Licence 2.0

--- a/idb-iegap.js
+++ b/idb-iegap.js
@@ -241,8 +241,6 @@
         }
     }
 
-    //This code was adapted from: https://github.com/yathit/ydn-db.
-    //All credits and rights go to their respective owners.
     var YDNEncoder = (function() {
         var p16 = 0x10000;
         var p32 = 0x100000000;

--- a/idb-iegap.js
+++ b/idb-iegap.js
@@ -241,11 +241,309 @@
         }
     }
 
+    //This code was adapted from: https://github.com/yathit/ydn-db.
+    //All credits and rights go to their respective owners.
+    var YDNEncoder = (function() {
+        var p16 = 0x10000;
+        var p32 = 0x100000000;
+        var p48 = 0x1000000000000;
+        var p52 = 0x10000000000000;
+        var pNeg1074 = 5e-324;                      // 2^-1074);
+        var pNeg1022 = 2.2250738585072014e-308;     // 2^-1022
+        var secondLayer = 0x3FFF + 0x7F;
+        var ARRAY_TERMINATOR = {},
+          BYTE_TERMINATOR = 0,
+          TYPE_NUMBER = 1,
+          TYPE_DATE = 2,
+          TYPE_STRING = 3,
+          TYPE_ARRAY = 4,
+          MAX_TYPE_BYTE_SIZE = 12; // NOTE: Cannot be greater than 255
+
+        var ieee754 = function(number) {
+            var s = 0, e = 0, m = 0;
+            if (number !== 0) {
+                if (isFinite(number)) {
+                    if (number < 0) {
+                        s = 1;
+                        number = -number;
+                    }
+                    var p = 0;
+                    if (number >= pNeg1022) {
+                        var n = number;
+                        while (n < 1) {
+                            p--;
+                            n *= 2;
+                        }
+                        while (n >= 2) {
+                            p++;
+                            n /= 2;
+                        }
+                        e = p + 1023;
+                    }
+                    m = e ? Math.floor((number / Math.pow(2, p) - 1) * p52) :
+                      Math.floor(number / pNeg1074);
+                }
+                else {
+                    e = 0x7FF;
+                    if (isNaN(number)) {
+                        m = 2251799813685248; // QNan
+                    }
+                    else {
+                        if (number === -Infinity) s = 1;
+                    }
+                }
+            }
+            return {sign: s, exponent: e, mantissa: m};
+        };
+
+        var encodeNumber = function(writer, number) {
+            var iee_number = ieee754(number);
+            if (iee_number.sign) {
+                iee_number.mantissa = p52 - 1 - iee_number.mantissa;
+                iee_number.exponent = 0x7FF - iee_number.exponent;
+            }
+            var word, m = iee_number.mantissa;
+
+            writer.write((iee_number.sign ? 0 : 0x80) | (iee_number.exponent >> 4));
+            writer.write((iee_number.exponent & 0xF) << 4 | (0 | m / p48));
+
+            m %= p48;
+            word = 0 | m / p32;
+            writer.write(word >> 8, word & 0xFF);
+
+            m %= p32;
+            word = 0 | m / p16;
+            writer.write(word >> 8, word & 0xFF);
+
+            word = m % p16;
+            writer.write(word >> 8, word & 0xFF);
+        };
+
+        var encodeString = function(writer, string) {
+            /* 3 layers:
+             Chars 0         - 7E            are encoded as 0xxxxxxx with 1 added
+             Chars 7F        - (3FFF+7F)     are encoded as 10xxxxxx xxxxxxxx with 7F subtracted
+             Chars (3FFF+80) - FFFF          are encoded as 11xxxxxx xxxxxxxx xx000000
+             */
+            for (var i = 0; i < string.length; i++) {
+                var code = string.charCodeAt(i);
+                if (code <= 0x7E) {
+                    writer.write(code + 1);
+                }
+                else if (code <= secondLayer) {
+                    code -= 0x7F;
+                    writer.write(0x80 | code >> 8, code & 0xFF);
+                }
+                else {
+                    writer.write(0xC0 | code >> 10, code >> 2 | 0xFF, (code | 3) << 6);
+                }
+            }
+            writer.write(BYTE_TERMINATOR);
+        };
+
+        var decodeNumber = function(reader) {
+            var b = reader.read() | 0;
+            var sign = b >> 7 ? false : true;
+
+            var s = sign ? -1 : 1;
+
+            var e = (b & 0x7F) << 4;
+            b = reader.read() | 0;
+            e += b >> 4;
+            if (sign) e = 0x7FF - e;
+
+            var tmp = [sign ? (0xF - (b & 0xF)) : b & 0xF];
+            var i = 6;
+            while (i--) tmp.push(sign ? (0xFF - (reader.read() | 0)) : reader.read() | 0);
+
+            var m = 0;
+            i = 7;
+            while (i--) m = m / 256 + tmp[i];
+            m /= 16;
+
+            if (m === 0 && e === 0) return 0;
+            return (m + 1) * Math.pow(2, e - 1023) * s;
+        };
+
+        var decodeString = function(reader) {
+            var buffer = [], layer = 0, unicode = 0, count = 0, $byte, tmp;
+            while (true) {
+                $byte = reader.read();
+                if ($byte === 0 || $byte == null) break;
+
+                if (layer === 0) {
+                    tmp = $byte >> 6;
+                    if (tmp < 2 && !isNaN($byte)) { // kyaw: add !isNaN($byte)
+                        buffer.push(String.fromCharCode($byte - 1));
+                    }
+                    else // tmp equals 2 or 3
+                    {
+                        layer = tmp;
+                        unicode = $byte << 10;
+                        count++;
+                    }
+                }
+                else if (layer === 2) {
+                    buffer.push(String.fromCharCode(unicode + $byte + 0x7F));
+                    layer = unicode = count = 0;
+                }
+                else // layer === 3
+                {
+                    if (count === 2) {
+                        unicode += $byte << 2;
+                        count++;
+                    }
+                    else // count === 3
+                    {
+                        buffer.push(String.fromCharCode(unicode | $byte >> 6));
+                        layer = unicode = count = 0;
+                    }
+                }
+            }
+            return buffer.join('');
+        };
+
+        function HexStringWriter() {
+            this.buffer = [];
+            this.c = undefined;
+        }
+
+        HexStringWriter.prototype.write = function(var_args) {
+            for (var i = 0; i < arguments.length; i++) {
+                this.c = arguments[i].toString(16);
+                this.buffer.push(this.c.length === 2 ? this.c : this.c = '0' + this.c);
+            }
+        };
+
+        HexStringWriter.prototype.trim = function() {
+            var length = this.buffer.length;
+            while (this.buffer[--length] === '00') {
+            }
+            this.buffer.length = ++length;
+            return this;
+        };
+
+        HexStringWriter.prototype.toString = function() {
+            return this.buffer.length ? this.buffer.join('') : '';
+        };
+
+        function HexStringReader(string) {
+            this.current = null;
+            this.string = string;
+            this.lastIndex = this.string.length - 1;
+            this.index = -1;
+        }
+
+        HexStringReader.prototype.read = function() {
+            return this.current = this.index < this.lastIndex ? parseInt(
+              this.string.charAt(++this.index) + this.string.charAt(++this.index), 16) :
+              null;
+        };
+
+        function Encoder() {
+        }
+
+        Encoder.prototype.compoundToString = function(key) {
+            var stack = [key], writer = new HexStringWriter(), type = 0,
+              dataType, obj;
+            while ((obj = stack.pop()) !== undefined) {
+                if (type % 4 === 0 && type + TYPE_ARRAY >
+                  MAX_TYPE_BYTE_SIZE) {
+                    writer.write(type);
+                    type = 0;
+                }
+                dataType = typeof obj;
+                if (obj instanceof Array) {
+                    type += TYPE_ARRAY;
+                    if (obj.length > 0) {
+                        stack.push(ARRAY_TERMINATOR);
+                        var i = obj.length;
+                        while (i--) stack.push(obj[i]);
+                        continue;
+                    }
+                    else {
+                        writer.write(type);
+                    }
+                }
+                else if (dataType === 'number') {
+                    type += TYPE_NUMBER;
+                    writer.write(type);
+                    encodeNumber(writer, obj);
+                }
+                else if (obj instanceof Date) {
+                    type += TYPE_DATE;
+                    writer.write(type);
+                    encodeNumber(writer, obj.valueOf());
+                }
+                else if (dataType === 'string') {
+                    type += TYPE_STRING;
+                    writer.write(type);
+                    encodeString(writer, obj);
+                }
+                else if (obj === ARRAY_TERMINATOR) {
+                    writer.write(BYTE_TERMINATOR);
+                }
+                else return ''; // null;
+                type = 0;
+            }
+            return writer.trim().toString();
+        };
+
+        Encoder.prototype.stringToCompound = function(encodedKey) {
+            var rootArray = []; // one-element root array that contains the result
+            var parentArray = rootArray;
+            var type, arrayStack = [], depth, tmp;
+            var reader = new HexStringReader(encodedKey);
+            while (reader.read() != null) {
+                if (reader.current === 0) // end of array
+                {
+                    parentArray = arrayStack.pop();
+                    continue;
+                }
+                if (reader.current === null) {
+                    return rootArray[0];
+                }
+                do
+                {
+                    depth = reader.current / 4 | 0;
+                    type = reader.current % 4;
+                    for (var i = 0; i < depth; i++) {
+                        tmp = [];
+                        parentArray.push(tmp);
+                        arrayStack.push(parentArray);
+                        parentArray = tmp;
+                    }
+                    if (type === 0 && reader.current + TYPE_ARRAY > MAX_TYPE_BYTE_SIZE) {
+                        reader.read();
+                    }
+                    else break;
+                } while (true);
+
+                if (type === TYPE_NUMBER) {
+                    parentArray.push(decodeNumber(reader));
+                }
+                else if (type === TYPE_DATE) {
+                    parentArray.push(new Date(decodeNumber(reader)));
+                }
+                else if (type === TYPE_STRING) {
+                    parentArray.push(decodeString(reader)); // add new
+                }
+                else if (type === 0) // empty array case
+                {
+                    parentArray = arrayStack.pop();
+                }
+            }
+            return rootArray[0];
+        };
+
+        return Encoder;
+    })();
 
     //
     // Constants and imports
     //
     var POWTABLE = {};
+    var Encoder = new YDNEncoder();
     var IDBKeyRange = window.IDBKeyRange,
         IDBObjectStore = window.IDBObjectStore,
         IDBDatabase = window.IDBDatabase;
@@ -306,54 +604,11 @@
     }
 
     function compoundToString(a) {
-        /// <param name="a" type="Array"></param>
-        var l = a.length,
-            rv = new Array(l);
-        for (var i = 0; i < l; ++i) {
-            var part = a[i];
-            if (part instanceof Date)
-                rv[i] = "D" + unipack(part.getTime(), 4, 0);
-            else if (typeof part === 'string')
-                rv[i] = "S" + part;
-            else if (isNaN(part))
-                if (part)
-                    rv[i] = "J" + JSON.stringify(part);
-                else if (typeof part === 'undefined')
-                    rv[i] = "u" // undefined
-                else
-                    rv[i] = "0" // null
-            else
-                rv[i] = (part < 0 ? "N" : "n") + unipack(part, 5, 4);
-        }
-        return JSON.stringify(rv);
+        return Encoder.compoundToString(a);
     }
 
     function stringToCompound(s) {
-        var a = JSON.parse(s),
-            l = a.length,
-            rv = new Array(l);
-        for (var i = 0; i < l; ++i) {
-            var item = a[i];
-            var type = item[0];
-            var encoded = item.substr(1);
-            var value = undefined;
-            if (type === "D")
-                value = new Date(uniback(encoded, 4, 0));
-            else if (type === "J")
-                value = JSON.parse(encoded);
-            else if (type === "S")
-                value = encoded;
-            else if (type === "N")
-                value = uniback(encoded, 5, 4, true);
-            else if (type === "n")
-                value = uniback(encoded, 5, 4, false);
-            else if (type === "u")
-                value = undefined;
-            else if (type === "0")
-                value = null
-            rv[i] = value;
-        }
-        return rv;
+        return Encoder.stringToCompound(s);
     }
 
     function getMeta(db) {

--- a/test/tests-common.js
+++ b/test/tests-common.js
@@ -2,7 +2,7 @@
 ///<reference path="../bower_components/dexie/dist/latest/Dexie.js" />
 
 (function () {
-
+    Dexie.delete('iegap-unit-test-database'); //clear the database so as to not have stale data
     var db = new Dexie("iegap-unit-test-database");
     db.version(1).stores({
         users: '[customer+userid],userid,[customer+displayName],*&email'
@@ -31,6 +31,16 @@
         db.users.where("[customer+displayName]").equals(["awarica","David"]).first(function (user) {
             ok(!!user, "User found");
             equal(user.userid, "dfahlander", "User correct");
+        }).catch(function (err) {
+            ok(false, err);
+        }).finally(start);
+    });
+
+    asyncTest('compound-key range', function() {
+        var range = IDBKeyRange.bound(['awarica'],  ['awarica', 'David'], false, false);
+        db.users.get(range, function(users) {
+            ok(!!users, "Users found");
+            equal(users.userid, "dfahlander", "User correct");
         }).catch(function (err) {
             ok(false, err);
         }).finally(start);


### PR DESCRIPTION
The current algorithm used in iegap will not generate successive strings when the compound key values have varying lengths. This results in a DataError exception when trying to handle bound keys of the following kind: 

`IDBKeyRange.bound(['someValue'],  ['someValue', 'someOtherValue'], false, false)` 

because the compounded lower bound value is "larger" than the upper bound value

This change would be a breaking change since all the existing keys would not be valid anymore.
The implementation is taken straight out of [ydn-db](https://github.com/yathit/ydn-db/blob/master/src/ydn/db/base/utils.js)

I'm not sure if this could be fixed using the current algorithm without also breaking backwards compatibility.
